### PR TITLE
Omit non-orcid contrib-id value from JATS-to-UNIXREF XSL conversion

### DIFF
--- a/src/data/xsl/jats-to-unixref.xsl
+++ b/src/data/xsl/jats-to-unixref.xsl
@@ -269,7 +269,7 @@
 					<xsl:call-template name="contributor-sequence"/>
 					<xsl:apply-templates select="name" mode="contrib"/>
 					<xsl:apply-templates select="xref[@ref-type='aff']" mode="contrib"/>
-					<xsl:apply-templates select="contrib-id" mode="contrib"/>
+					<xsl:apply-templates select="contrib-id[@contrib-id-type='orcid']" mode="contrib"/>
 				</person_name>
 			</xsl:when>
 			<xsl:when test="collab">

--- a/tests/example-jats-1-0.xml
+++ b/tests/example-jats-1-0.xml
@@ -33,6 +33,7 @@
             <contrib-group content-type="authors">
                 <contrib id="author-1" contrib-type="author" corresp="yes">
                     <contrib-id contrib-id-type="orcid">1234-1234-1234-1234</contrib-id>
+                    <contrib-id contrib-id-type="twitter-username">AbcDefGHi</contrib-id>
                     <name>
                         <surname>Farke</surname>
                         <given-names>Andrew A.</given-names>

--- a/tests/example-jats-1-1.xml
+++ b/tests/example-jats-1-1.xml
@@ -33,6 +33,7 @@
             <contrib-group content-type="authors">
                 <contrib id="author-1" contrib-type="author" corresp="yes">
                     <contrib-id contrib-id-type="orcid">1234-1234-1234-1234</contrib-id>
+                    <contrib-id contrib-id-type="twitter-username">AbcDefGHi</contrib-id>
                     <name>
                         <surname>Farke</surname>
                         <given-names>Andrew A.</given-names>


### PR DESCRIPTION
 When `contrib-id-type` is not `orchid`, omit the `contrib-id` value.  An JATS example with a `contrib-id-type` of `twitter-username` meant that the value of the `contrib-id` was inserted as an erroneous child text node to the UNIXREF `person-name` element, fixes issue #146 