### PR TITLE
Fix contrib. affiliations unbounded with JATS vs. bounded with Crossref

### DIFF
--- a/src/data/xsl/jats-to-unixref.xsl
+++ b/src/data/xsl/jats-to-unixref.xsl
@@ -268,7 +268,7 @@
 				<person_name contributor_role="author" sequence="additional">
 					<xsl:call-template name="contributor-sequence"/>
 					<xsl:apply-templates select="name" mode="contrib"/>
-					<xsl:apply-templates select="xref[@ref-type='aff']" mode="contrib"/>
+					<xsl:apply-templates select="xref[@ref-type='aff'][position() &lt;= 5]" mode="contrib"/>
 					<xsl:apply-templates select="contrib-id[@contrib-id-type='orcid']" mode="contrib"/>
 				</person_name>
 			</xsl:when>


### PR DESCRIPTION
The Crossref schema, only supports 5 affiliations so only converts the first 5 affiliations from the JATS xml document.

fixes #158